### PR TITLE
Include user defined nonce in status file

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ It is possible to download files from AWS S3 as long as the proper AWS S3 url is
 | gtfsAndOsmUrls | array | Optional | | An array of GTFS and OSM urls that should be downloaded. |
 | jarFile | string | Optional | /opt/otp-1.4.0-shaded.jar | The full path to the OTP jar file. |
 | jarUrl | string | Optional | https://repo1.maven.org/maven2/org/opentripplanner/otp/1.4.0/otp-1.4.0-shaded.jar | A url where the OTP jar can be downloaded from. |
+| nonce | string | Optional | | A value that will be written in status.json files in order to verify that the status file was produced by a particular run with the provided config. |
 | otpRunnerLogFile | string | Optional | /var/log/otp-runner.log | The path where the otp-runner logs should be written to. |
 | prefixLogUploadsWithInstanceId | boolean | Optional | false | If true, will obtain the ec2 instance ID and prefix the otp-runner and otp-server log files with this instance ID when uploading to s3. |
 | routerConfigJSON | string | Optional | | The raw contents to write to the router-config.json file. |

--- a/__tests__/__snapshots__/otp-runner.js.snap
+++ b/__tests__/__snapshots__/otp-runner.js.snap
@@ -83,6 +83,7 @@ Object {
   "graphBuilt": false,
   "graphUploaded": false,
   "message": "Failed to download file: s3://mock-bucket/failme.jar. Error: Error: mock download failure",
+  "nonce": "bad-jar-download-nonce",
   "numFilesDownloaded": 1,
   "pctProgress": 20,
   "serverStarted": false,

--- a/__tests__/fixtures/bad-jar-download.json
+++ b/__tests__/fixtures/bad-jar-download.json
@@ -5,5 +5,6 @@
   "jarUrl": "s3://mock-bucket/failme.jar",
   "graphsFolder": "./temp-test-files/",
   "gtfsAndOsmUrls": ["s3://mock-bucket/gtfs.zip"],
+  "nonce": "bad-jar-download-nonce",
   "statusFileLocation": "./temp-test-files/status.json"
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,6 +38,9 @@ module.exports = class OtpRunner {
       pctProgress: 0,
       totalFilesToDownload: 0
     }
+    if (manifest.nonce) {
+      this.status.nonce = manifest.nonce
+    }
     // print some startup messages
     this.log.info(`
       __

--- a/manifest-json-schema.json
+++ b/manifest-json-schema.json
@@ -43,6 +43,10 @@
       "description": "A url where the OTP jar can be downloaded from.",
       "default": "https://repo1.maven.org/maven2/org/opentripplanner/otp/1.4.0/otp-1.4.0-shaded.jar"
     },
+    "nonce": {
+      "type": "string",
+      "description": "A value that will be written in status.json files in order to verify that the status file was produced by a particular run with the provided config."
+    },
     "otpRunnerLogFile": {
       "type": "string",
       "description": "The path where the otp-runner logs should be written to.",


### PR DESCRIPTION
This PR allows for the inclusion of a nonce in the output of status files. This can be used by external programs to verify the integrity of the status file.