### PR TITLE
Upload Manifest to Pelias Webhook

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -745,6 +745,31 @@ module.exports = class OtpRunner {
   }
 
   /**
+   * If told to, will trigger the Pelias custom instance webhook to update
+   * the custom GTFS and CSV data
+   */
+  async updatePeliasInstance () {
+    if (this.manifest && this.manifest.updateCustomPelias) {
+        const response = await fetch('http://ec2-3-236-166-78.compute-1.amazonaws.com/webhook', {
+          method: 'POST',
+          headers: {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+            // TODO: This absolutely needs to be read from a configuration file!
+            // or the webhook in some other way only accepts requests from
+            // otp-runner. Does it always run on the same host?
+            'Authorization': `Basic test:test`
+          },
+          body: JSON.stringify(this.manifest)
+        });
+        if (response.status !== 200) {
+          this.log.error('An error occurred when uploading the manifest to Pelias! See error:')
+          this.log.error(await response.text())
+        }
+  }
+}
+
+  /**
    * The main entry point for the otp-runner script. Does the following:
    * - validates the manifest
    * - deletes and then recreates an empty router folder
@@ -754,6 +779,7 @@ module.exports = class OtpRunner {
    * - uploads the built Graph.obj file if needed
    * - uploads a bundle if needed
    * - uploads various logs as needed
+   * - uploads manifest to Pelias server
    */
   async run () {
     await this.validateManifest()
@@ -762,6 +788,7 @@ module.exports = class OtpRunner {
     await this.buildGraph()
     await this.runPostBuildTasks()
     await this.uploadOtpRunnerLogs()
+    await this.updatePeliasInstance()
 
     // If runServer is true, the execa subprocess hangs for unknown reasons that
     // seem to be related to reading the stdout/stderr stream. Therefore,

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "execa": "^4.0.0",
     "fs-extra": "^9.0.0",
     "got": "^10.7.0",
+    "node-fetch": "^2.6.1",
     "simple-node-logger": "^18.12.24"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5838,6 +5838,11 @@ node-fetch@^1.0.1:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
+node-fetch@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"


### PR DESCRIPTION
This, relying on 2 new fields in the manifest.json generated by data tools, allows for updating a custom Pelias instance with CSV POIs and GTFS stops.

A few questions for expected behavior 

- [ ] The Pelias web hook endpoint should probably be loaded in from somewhere instead of hardcoded, but where is a good place to put it?

- [ ] By default, all GTFS feeds are sent to Pelias. Should this be configurable?
- [ ] The web hook authorization could use some work, and shouldn't be hardcoded