### PR TITLE
Avoid Timeout on new OTP2 Versions

### DIFF
--- a/__tests__/__snapshots__/otp-runner.js.snap
+++ b/__tests__/__snapshots__/otp-runner.js.snap
@@ -247,7 +247,7 @@ exports[`otp-runner mocked runner tests successes should use otp 2.x to build a 
 exports[`otp-runner mocked runner tests successes should use otp 2.x to build a graph and start a server 4`] = `"Mock building completed successfully!"`;
 
 exports[`otp-runner mocked runner tests successes should use otp 2.x to build a graph and start a server 5`] = `
-"22:10:49.222 INFO (Graph.java:731) Graph read. |V|=156146 |E|=397357
+"22:10:49.222 INFO (Graph.java:731) Transit loaded. |V|=156146 |E|=397357
 22:10:53.765 INFO (GrizzlyServer.java:153) Grizzly server running."
 `;
 

--- a/__tests__/test-utils/mocks/cli-processes.js
+++ b/__tests__/test-utils/mocks/cli-processes.js
@@ -177,7 +177,7 @@ function mockOTPServerStart ({
       const logs = []
       if (graphLoad) {
         if (otpV2) {
-          logs.push('22:10:49.222 INFO (Graph.java:731) Graph read. |V|=156146 |E|=397357')
+          logs.push('22:10:49.222 INFO (Graph.java:731) Transit loaded. |V|=156146 |E|=397357')
         } else {
           logs.push('22:10:49.222 INFO (Graph.java:731) Main graph read. |V|=156146 |E|=397357')
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 /**
  * This script will automate common tasks with OpenTripPlanner such as
- * downloading needed OSM and GTFS files, builing a graph and running a graph.
+ * downloading needed OSM and GTFS files, building a graph and running a graph.
  */
 
 const { spawn } = require('child_process')

--- a/lib/index.js
+++ b/lib/index.js
@@ -554,7 +554,7 @@ module.exports = class OtpRunner {
       if (
         data.includes(
           this.isUsingOtp2x()
-            ? 'Graph read.'
+            ? 'Transit loaded.'
             : 'Main graph read.'
         )
       ) {


### PR DESCRIPTION
OTP2 has had a change to the log output: https://github.com/opentripplanner/OpenTripPlanner/commit/496e097e31b9565f7c7c373ade68c1c24d40e8c5

This change causes otp-runner to timeout as it no longer detects OTP2 as having started correctly. This PR corrects otp-runner's log reading