### PR TITLE
refactor(util): use newer java memory args

### DIFF
--- a/__tests__/__snapshots__/otp-runner.js.snap
+++ b/__tests__/__snapshots__/otp-runner.js.snap
@@ -258,7 +258,7 @@ exports[`otp-runner mocked runner tests successes should use otp 2.x to build a 
 exports[`otp-runner unit tests should generate 1.x build cli arguments 1`] = `
 Array [
   "-jar",
-  "-Xmx7902848k",
+  "-XX:MaxRAMPercentage=80",
   "./temp-test-files/ok.jar",
   "--build",
   "temp-test-files/default",
@@ -268,7 +268,7 @@ Array [
 exports[`otp-runner unit tests should generate 1.x serve cli arguments 1`] = `
 Array [
   "-jar",
-  "-Xmx7902848k",
+  "-XX:MaxRAMPercentage=80",
   "./temp-test-files/ok.jar",
   "--server",
   "--graphs",
@@ -281,7 +281,7 @@ Array [
 exports[`otp-runner unit tests should generate 2.x build cli arguments 1`] = `
 Array [
   "-jar",
-  "-Xmx7902848k",
+  "-XX:MaxRAMPercentage=80",
   "./temp-test-files/ok.jar",
   "--build",
   "--save",
@@ -292,7 +292,7 @@ Array [
 exports[`otp-runner unit tests should generate 2.x serve cli arguments 1`] = `
 Array [
   "-jar",
-  "-Xmx7902848k",
+  "-XX:MaxRAMPercentage=80",
   "./temp-test-files/ok.jar",
   "--load",
   "./temp-test-files/",

--- a/__tests__/test-utils/mocks/cli-processes.js
+++ b/__tests__/test-utils/mocks/cli-processes.js
@@ -85,7 +85,7 @@ function getS3Uploads () {
 function mockOTPGraphBuild (shouldPass = false, otpV2 = false) {
   const javaArgs = [
     '-jar',
-    '-Xmx7902848k'
+    '-XX:MaxRAMPercentage=80'
   ]
   const baseFolder = otpV2
     ? `${TEMP_TEST_FOLDER}/otp2-base-folder`
@@ -157,7 +157,7 @@ function mockOTPServerStart ({
 }) {
   const javaArgs = [
     '-jar',
-    '-Xmx7902848k'
+    '-XX:MaxRAMPercentage=80'
   ]
   if (otpV2) {
     javaArgs.push(`./${TEMP_TEST_FOLDER}/ok-otp-2.jar`)

--- a/lib/util.js
+++ b/lib/util.js
@@ -31,13 +31,7 @@ module.exports.downloadFileIfNeeded = async function ({ dest, uri }) {
  * the given jar file.
  */
 module.exports.getBaseOTPArgs = function (jarFile) {
-  // Use potentially all available memory minus 2GB for the OS, but use a
-  // minimum of 1.5GB to run OTP.
-  const memoryToUse = Math.max(
-    Math.round(os.totalmem() / 1000 - 2097152),
-    1500000
-  )
-  return ['-jar', `-Xmx${memoryToUse}k`, jarFile]
+  return ['-jar', '-XX:MaxRAMPercentage=80',  jarFile]
 }
 
 module.exports.waitOneSecond = async function () {

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,4 +1,3 @@
-const os = require('os')
 const stream = require('stream')
 const {promisify} = require('util')
 
@@ -31,7 +30,7 @@ module.exports.downloadFileIfNeeded = async function ({ dest, uri }) {
  * the given jar file.
  */
 module.exports.getBaseOTPArgs = function (jarFile) {
-  return ['-jar', '-XX:MaxRAMPercentage=80',  jarFile]
+  return ['-jar', '-XX:MaxRAMPercentage=80', jarFile]
 }
 
 module.exports.waitOneSecond = async function () {


### PR DESCRIPTION
The old memory arg was clever, but caused some problem on larger-ram instances, were otp would use far too much ram. This new approach uses a consistent 80%. Thoughts on bumping this up to 90?