### PR TITLE
add `--abortOnUnknownConfig` to OTP graph builds

### DIFF
--- a/__tests__/__snapshots__/otp-runner.js.snap
+++ b/__tests__/__snapshots__/otp-runner.js.snap
@@ -285,6 +285,7 @@ Array [
   "./temp-test-files/ok.jar",
   "--build",
   "--save",
+  "--abortOnUnknownConfig",
   "./temp-test-files/",
 ]
 `;

--- a/__tests__/fixtures/otp-2-build-and-server-manifest.json
+++ b/__tests__/fixtures/otp-2-build-and-server-manifest.json
@@ -1,6 +1,7 @@
 {
   "baseFolder": "./temp-test-files/otp2-base-folder",
   "baseFolderDownloads": [{ "uri": "s3://mock-bucket/gtfs.zip" }],
+  "buildConfigJSON": "{}",
   "buildGraph": true,
   "buildLogFile": "./temp-test-files/otp-build.log",
   "jarFile": "./temp-test-files/ok-otp-2.jar",
@@ -8,7 +9,7 @@
   "graphObjUri": "s3://mock-bucket/graph.obj",
   "otpRunnerLogFile": "./temp-test-files/otp-runner.log",
   "otpVersion": "2.x",
-  "routerConfigJSON": "{\"timeout\": 4}",
+  "routerConfigJSON": "{}",
   "s3UploadPath": "s3://mock-bucket",
   "serverLogFile": "./temp-test-files/otp-server.log",
   "statusFileLocation": "./temp-test-files/status.json",

--- a/__tests__/fixtures/otp-2-build-and-server-manifest.json
+++ b/__tests__/fixtures/otp-2-build-and-server-manifest.json
@@ -1,7 +1,6 @@
 {
   "baseFolder": "./temp-test-files/otp2-base-folder",
   "baseFolderDownloads": [{ "uri": "s3://mock-bucket/gtfs.zip" }],
-  "buildConfigJSON": "{\"htmlAnnotations\": true}",
   "buildGraph": true,
   "buildLogFile": "./temp-test-files/otp-build.log",
   "jarFile": "./temp-test-files/ok-otp-2.jar",

--- a/__tests__/fixtures/otp-2-build-and-server-manifest.json
+++ b/__tests__/fixtures/otp-2-build-and-server-manifest.json
@@ -1,7 +1,7 @@
 {
   "baseFolder": "./temp-test-files/otp2-base-folder",
   "baseFolderDownloads": [{ "uri": "s3://mock-bucket/gtfs.zip" }],
-  "buildConfigJSON": "{}",
+  "buildConfigJSON": "{\"htmlAnnotations\": true}",
   "buildGraph": true,
   "buildLogFile": "./temp-test-files/otp-build.log",
   "jarFile": "./temp-test-files/ok-otp-2.jar",
@@ -9,7 +9,7 @@
   "graphObjUri": "s3://mock-bucket/graph.obj",
   "otpRunnerLogFile": "./temp-test-files/otp-runner.log",
   "otpVersion": "2.x",
-  "routerConfigJSON": "{}",
+  "routerConfigJSON": "{\"timeout\": 4}",
   "s3UploadPath": "s3://mock-bucket",
   "serverLogFile": "./temp-test-files/otp-server.log",
   "statusFileLocation": "./temp-test-files/status.json",

--- a/__tests__/test-utils/mocks/cli-processes.js
+++ b/__tests__/test-utils/mocks/cli-processes.js
@@ -94,6 +94,7 @@ function mockOTPGraphBuild (shouldPass = false, otpV2 = false) {
     javaArgs.push(`./${TEMP_TEST_FOLDER}/ok-otp-2.jar`)
     javaArgs.push('--build')
     javaArgs.push('--save')
+    javaArgs.push('--abortOnUnknownConfig')
     javaArgs.push(`./${baseFolder}`)
   } else {
     javaArgs.push(`./${TEMP_TEST_FOLDER}/ok.jar`)

--- a/lib/index.js
+++ b/lib/index.js
@@ -364,6 +364,7 @@ module.exports = class OtpRunner {
     args.push('--build')
     if (this.isUsingOtp2x()) {
       args.push('--save')
+      args.push('--abortOnUnknownConfig')
     }
     args.push(this.getTargetFolder())
     return args

--- a/lib/index.js
+++ b/lib/index.js
@@ -267,7 +267,7 @@ module.exports = class OtpRunner {
       ${errors.join('\n')}`)
     }
 
-    // if this point is reached, the manfiest.json file is valid!
+    // if this point is reached, the manifest.json file is valid!
     this.log.info('manifest is valid!')
     this.log.info(JSON.stringify(this.manifest, null, 2))
   }


### PR DESCRIPTION
This PR adds the new abort on unknown config flag to graph builds. This will cause some crashes initially but should result in better config files overall.